### PR TITLE
Add a class to detect the ProjectType of a gradle project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+build/
+.gradle/
+
+out/
+.idea/
+*.ipr
+*.iml
+*.iws
+
+.classpath
+.project

--- a/src/main/groovy/nebula/core/ProjectType.groovy
+++ b/src/main/groovy/nebula/core/ProjectType.groovy
@@ -1,0 +1,17 @@
+package nebula.core
+
+import groovy.transform.Canonical
+import org.gradle.api.Project
+
+@Canonical
+class ProjectType {
+    boolean isRootProject
+    boolean isParentProject
+    boolean isLeafProject
+
+    ProjectType(Project project) {
+        isRootProject = (project == project.rootProject)
+        isParentProject = project.rootProject.subprojects.any { it.parent == project } // Parent of any projects, aka Uncle/Aunt project
+        isLeafProject = !isParentProject
+    }
+}

--- a/src/test/groovy/nebula/core/ProjectTypeSpec.groovy
+++ b/src/test/groovy/nebula/core/ProjectTypeSpec.groovy
@@ -1,0 +1,32 @@
+package nebula.core
+
+import nebula.test.ProjectSpec
+import org.gradle.testfixtures.ProjectBuilder
+
+class ProjectTypeSpec extends ProjectSpec {
+    def 'single project is properly identified as a root and leaf'() {
+        when:
+        def singleProject = new ProjectType(project)
+
+        then:
+        singleProject.isRootProject
+        singleProject.isLeafProject
+        !singleProject.isParentProject    
+    }
+
+    def 'multiproject identifies subprojects as leaf and top level as root and parent'() {
+        def sub1 = ProjectBuilder.builder().withName('sub1').withParent(project).build()
+
+        when:
+        def multiProject = new ProjectType(project)
+        def multiSub1 = new ProjectType(sub1)
+
+        then:
+        multiProject.isRootProject
+        multiProject.isParentProject
+        !multiProject.isLeafProject
+        !multiSub1.isRootProject
+        !multiSub1.isParentProject
+        multiSub1.isLeafProject
+    }
+}


### PR DESCRIPTION
This may be used when applying a plugin if it needs to behave differently on a top level organizational project or a leaf project which produces artifacts.
